### PR TITLE
Improvements: `is-disabled` + multiple modifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,17 +9,20 @@ const makeBlockStyles = ({
   loading,
   modifier,
   ...props
-}) => ({
-  className: cx(block, {
-    [`${block}--${modifier}`]: block && modifier,
-    [`${className}`]: className,
-    'is-active': active,
-    'is-disabled': disabled,
-    'is-hidden': hidden,
-    'is-loading': loading
-  }),
-  ...props
-})
+}) => {
+  const modifiers = (block && modifier) ? modifier.split(/\s/).map((item) => (`${block}--${item}`)).join(' ') : false
+
+  return ({
+    className: cx(block, modifiers, {
+      [`${className}`]: className,
+      'is-active': active,
+      'is-disabled': disabled,
+      'is-hidden': hidden,
+      'is-loading': loading
+    }),
+    ...props
+  })
+}
 
 export default (block) => ({ element, ...props }) => {
   if (element) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const makeBlockStyles = ({
   active,
   block,
   className,
+  disabled,
   hidden,
   loading,
   modifier,
@@ -13,6 +14,7 @@ const makeBlockStyles = ({
     [`${block}--${modifier}`]: block && modifier,
     [`${className}`]: className,
     'is-active': active,
+    'is-disabled': disabled,
     'is-hidden': hidden,
     'is-loading': loading
   }),

--- a/test.js
+++ b/test.js
@@ -44,6 +44,23 @@ test('should render `header` block with modifier', (t) => {
   )
 })
 
+test('should render `header` block with multiple modifiers', (t) => {
+  const renderer = createRenderer()
+
+  const dumbBemHeader = dumbBem('header')
+  const Header = tx(dumbBemHeader)('header')
+
+  renderer.render(
+    <Header modifier='landing landing-seo' />
+  )
+  expect(
+    renderer.getRenderOutput()
+  )
+  .toEqualJSX(
+    <header className='header header--landing header--landing-seo' />
+  )
+})
+
 test('should render `header` block with modifier and custom className', (t) => {
   const renderer = createRenderer()
 
@@ -58,6 +75,23 @@ test('should render `header` block with modifier and custom className', (t) => {
   )
   .toEqualJSX(
     <header className='header header--landing js-header' />
+  )
+})
+
+test('should render `header` block with multiple modifiers and custom className', (t) => {
+  const renderer = createRenderer()
+
+  const dumbBemHeader = dumbBem('header')
+  const Header = tx(dumbBemHeader)('header')
+
+  renderer.render(
+    <Header modifier='landing landing-seo' className='js-header' />
+  )
+  expect(
+    renderer.getRenderOutput()
+  )
+  .toEqualJSX(
+    <header className='header header--landing header--landing-seo js-header' />
   )
 })
 

--- a/test.js
+++ b/test.js
@@ -85,12 +85,12 @@ test('should render `foo` block with modifiers', (t) => {
   const Foo = tx(dumbBemFoo)('div')
 
   renderer.render(
-    <Foo active hidden loading />
+    <Foo active disabled hidden loading />
   )
   expect(
     renderer.getRenderOutput()
   )
   .toEqualJSX(
-    <div className='foo is-active is-hidden is-loading' />
+    <div className='foo is-active is-disabled is-hidden is-loading' />
   )
 })


### PR DESCRIPTION
Two things:
- `is-disabled` - added new state class
- multiple modifiers:

```
<Block modifier='abc def`/>
```

will generate:

```
<div class='block block--abc block--def'></div>
```

what do you think?
