### PR TITLE
Pass block directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 import cx from 'classnames'
 
-const makeBlockStyles = ({
+const makeBlockStyles = (block, {
   active,
-  block,
   className,
   disabled,
   hidden,
@@ -10,7 +9,7 @@ const makeBlockStyles = ({
   modifier,
   ...props
 }) => {
-  const modifiers = (block && modifier) ? modifier.split(/\s/).map((item) => (`${block}--${item}`)).join(' ') : false
+  const modifiers = modifier && modifier.split(/\s+/).map((item) => `${block}--${item}`)
   const states = {
     'is-active': active,
     'is-disabled': disabled,
@@ -25,8 +24,7 @@ const makeBlockStyles = ({
 }
 
 export default (block) => ({ element, ...props }) => {
-  if (element) {
-    return makeBlockStyles({ block: `${block}__${element}`, ...props })
-  }
-  return makeBlockStyles({ block, ...props })
+  const blockName = (element ? `${block}__${element}` : block)
+
+  return makeBlockStyles(blockName, props)
 }

--- a/test.js
+++ b/test.js
@@ -51,13 +51,13 @@ test('should render `header` block with multiple modifiers', (t) => {
   const Header = tx(dumbBemHeader)('header')
 
   renderer.render(
-    <Header modifier='landing landing-seo' />
+    <Header modifier='landing landing-seo   top' />
   )
   expect(
     renderer.getRenderOutput()
   )
   .toEqualJSX(
-    <header className='header header--landing header--landing-seo' />
+    <header className='header header--landing header--landing-seo header--top' />
   )
 })
 


### PR DESCRIPTION
If there was `block` in `params` it would've taken precedence.

Made the main function more readable.

Refactor of modifiers:
- Multiple whitespace works.
- No need to create string, `classnames` supports arrays.
