### PR TITLE
Add options param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2016-xx-xx
+### Add options
+- **Breaking** Enable further customisation via options. Move `extraMakers` to options.
+
 ## 1.1.1 - 2016-09-01
 ### Fix tests
 - Update ava

--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ ReactDOM.render(
 ```
 
 ## API
-### `dumbBem(block, extraMakers=[])`
+### `dumbBem(block, options={})`
 
 #### Arguments
 
   - `block` (*String*): name of the base block.
-  - [`extraMakers`] \(*Array*):
-  array of functions for adding new class names.
+  - `options` (*Object*): Override default options.
+    - [`extraMakers`] \(*Array*):
+    array of functions for adding new class names.
 
   Maker function takes `block` and `props` as arguments and should return anything suitable for [classnames](https://www.npmjs.com/package/classnames) input. E.g. [it can be a string, array of string or object](https://github.com/JedWatson/classnames#usage).
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ ReactDOM.render(
     - [`extraMakers`] \(*Array*):
     array of functions for adding new class names.
 
-  Maker function takes `block` and `props` as arguments and should return anything suitable for [classnames](https://www.npmjs.com/package/classnames) input. E.g. [it can be a string, array of string or object](https://github.com/JedWatson/classnames#usage).
+      Maker function takes `block` and `props` as arguments and should return anything suitable for [classnames](https://www.npmjs.com/package/classnames) input. E.g. [it can be a string, array of string or object](https://github.com/JedWatson/classnames#usage).
 
-  See also [built-in makers](docs/makers.md).
+      See also [built-in makers](docs/makers.md).
 
 #### Returns
 

--- a/docs/makers.md
+++ b/docs/makers.md
@@ -14,7 +14,7 @@ This maker is independent of the value of passed props.
 
 *This maker is always applied.*
 
-**Example**
+**Example**  
 ```js
 import makeBlock from 'dumb-bem/makers/makeBlock';
 
@@ -33,7 +33,7 @@ Separate multiple modifiers by whitespace.
 
 *This maker is always applied.*
 
-**Example**
+**Example**  
 ```js
 import makeModifiers from 'dumb-bem/makers/makeModifiers';
 
@@ -53,7 +53,7 @@ This maker is independent of the value of `block`.
 
 *This maker is always applied.*
 
-**Example**
+**Example**  
 ```js
 import makeOriginalClass from 'dumb-bem/makers/makeOriginalClass';
 
@@ -73,7 +73,7 @@ This maker is independent of the value of `block`.
 
 *This maker is always applied.*
 
-**Example**
+**Example**  
 ```js
 import makeStates from 'dumb-bem/makers/makeStates';
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ import makeStates from './makers/makeStates'
 
 const basicMakers = [makeBlock, makeOriginalClass, makeModifiers, makeStates]
 
-export default (block, extraMakers = []) => (props) => {
+export default (block, options = {}) => (props) => {
+  const { extraMakers = [] } = options
   const { element } = props
   const blockName = block + (element ? `__${element}` : '')
 


### PR DESCRIPTION
This is more of a POC.

Even though this library uses the most common separators there are people who use different ones. Cf. https://en.bem.info/method/naming-convention/

The proposed change enables that as well as it sets base any future customisation.
