### PR TITLE
Add peer dependency to tx

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "standard": "^7.1.2",
     "transform-props-with": "^2.0.0"
   },
+  "peerDependencies": {
+    "transform-props-with": "^2.0.0"
+  },
   "main": "lib/",
   "scripts": {
     "docs": "jsdoc2md --module-index-format grouped src/makers/*.js > docs/makers.md",


### PR DESCRIPTION
Make sure that this version of dumb-bem is compatible with the used version of tx.
