### PR TITLE
Make makeStates plugin optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - 2016-xx-xx
+### Make SMACSS states optional
+- Make `makeStates` plugin optional
+
 ## 2.0.0 - 2016-09-28
 ### Add options
 - **Breaking**: Enable further customisation via options.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,41 @@ A function which takes `props` object as a parameter, transforms `className` pro
 
 #### Examples
 
-**User maker function**
+**Use built-in maker function**
 
 ```js
+import dumbBem from 'dumb-bem'
+import { makeStates } from 'dumb-bem/plugins'
+import tx from 'transform-props-with'
+
+const dumbList = dumbBem('list', { plugins: [makeStates] })
+const List = tx(dumbList)('ul')
+const ListItem = tx([{ element: 'item' }, dumbList])('li')
+
+ReactDOM.render(
+  <List>
+    <ListItem active={true}>Item 1</ListItem>
+    <ListItem disabled={true}>Item 2</ListItem>
+    <ListItem hidden={true}>Item 3</ListItem>
+    <ListItem loading={true}>Item 4</ListItem>
+  </List>
+, node)
+
+// Would render:
+// <ul class='list'>
+//   <li class='list__item is-active'>Item 1</li>
+//   <li class='list__item is-disabled'>Item 2</li>
+//   <li class='list__item is-hidden'>Item 3</li>
+//   <li class='list__item is-loading'>Item 4</li>
+// </ul>
+```
+
+**Use custom maker function**
+
+```js
+import dumbBem from 'dumb-bem'
+import tx from 'transform-props-with'
+
 const colorModifierPlugin = {
   maker: (block, props) => {
     if (props.color) {
@@ -90,6 +122,7 @@ ReactDOM.render(
     <ListItem color='white'>Item 2</ListItem>
   </List>
 , node)
+
 // Would render:
 // <ul class='list'>
 //   <li class='list__item list__item--black'>Item 1</li>

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,10 @@ import cx from 'classnames'
 import * as pluginBlock from './plugins/makeBlock'
 import * as pluginModifiers from './plugins/makeModifiers'
 import * as pluginOriginalClass from './plugins/makeOriginalClass'
-import * as pluginStates from './plugins/makeStates'
 
 import filterObject from './filter-object'
 
-const basicPlugins = [pluginBlock, pluginModifiers, pluginOriginalClass, pluginStates]
+const basicPlugins = [pluginBlock, pluginModifiers, pluginOriginalClass]
 const defaultDelimiters = {
   element: '__',
   modifier: '--'

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,0 +1,3 @@
+import * as makeStatesPlugin from './makeStates'
+
+export const makeStates = makeStatesPlugin

--- a/test/index.js
+++ b/test/index.js
@@ -6,20 +6,20 @@ import React from 'react'
 import { createRenderer } from 'react-addons-test-utils'
 import tx from 'transform-props-with'
 
-import dumbBem from '../'
+import dumbBem from '../lib'
+import { makeStates } from '../lib/plugins'
 
 expect.extend(expectJSX)
 
-const dumbHeader = dumbBem('header')
+const dumbHeader = dumbBem('header', { plugins: [makeStates] })
 const justClass = (props) => dumbHeader(props).className.trim()
 
 test('should cleanup unknown properties', (t) => {
-  const dumbHeader = dumbBem('header', {
-    plugins: [{
-      maker: (_, { invisible }) => invisible && 'is-invisible',
-      propsToRemove: ['invisible']
-    }]
-  })
+  const makeInvisible = {
+    maker: (_, { invisible }) => invisible && 'is-invisible',
+    propsToRemove: ['invisible']
+  }
+  const dumbHeader = dumbBem('header', { plugins: [makeStates, makeInvisible] })
   const props = dumbHeader({ active: true, invisible: true, loading: true, modifier: 'landing' })
 
   t.false('active' in props)
@@ -41,7 +41,7 @@ test('should return `header` block', (t) => {
     renderer.getRenderOutput()
   )
   .toEqualJSX(
-    React.createElement('header', { className: 'header ' })
+    React.createElement('header', { className: 'header' })
   )
 })
 


### PR DESCRIPTION
Besides making that plugin optional I decided to make `plugins/index.js` which will contain all plugins we want to export outside.

re https://github.com/agudulin/dumb-bem/issues/6
