### PR TITLE
Remove unecessary spec + verbose flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "docs": "jsdoc2md --module-index-format grouped src/plugins/*.js > docs/plugins.md",
     "transpile": "babel src -d lib",
     "pretest": "npm run transpile",
-    "test": "standard && ava",
+    "test": "standard && ava -v",
     "prepush": "npm test && npm run docs",
     "prepublish": "npm run transpile",
     "postpublish": "rimraf index.es5.js"

--- a/test/index.js
+++ b/test/index.js
@@ -108,10 +108,3 @@ test('should return `foo` block with modifiers', (t) => {
     'header is-active is-disabled is-hidden is-loading'
   )
 })
-
-test('should return `foo` block with modifiers', (t) => {
-  t.is(
-    justClass({ active: true, disabled: true, hidden: true, loading: true }),
-    'header is-active is-disabled is-hidden is-loading'
-  )
-})


### PR DESCRIPTION
I did it, I fixed it :)

One scenario was tested twice.
I also added `verbose` option to Ava CLI to avoid similar situations in the future.
