### PR TITLE
[makeModifiers Plugin] Ignore empty modifiers

### DIFF
--- a/src/plugins/makeModifiers.js
+++ b/src/plugins/makeModifiers.js
@@ -23,7 +23,10 @@
  *   // => ['modifier']
  *
  */
-export const maker = (block, { modifier }, { delimiters }) =>
-  modifier && modifier.split(/\s+/).map((item) => `${block}${delimiters.modifier}${item}`)
+export const maker = (block, { modifier = '' }, { delimiters }) => {
+  const mod = modifier.trim()
+
+  return mod && mod.split(/\s+/).map(item => `${block}${delimiters.modifier}${item}`)
+}
 
 export const propsToRemove = ['modifier']

--- a/test/index.js
+++ b/test/index.js
@@ -81,6 +81,20 @@ test('should return `header` block with modifier and custom className', (t) => {
   )
 })
 
+test('should return `header` block without empty modifier', (t) => {
+  t.is(
+    justClass({ modifier: ' ' }),
+    'header'
+  )
+})
+
+test('should return `header` block with trimmed modifier', (t) => {
+  t.is(
+    justClass({ modifier: '  landing ' }),
+    'header header--landing'
+  )
+})
+
 test('should return `header` block with multiple modifiers and custom className', (t) => {
   t.is(
     justClass({ modifier: 'landing landing-seo', className: 'js-header' }),


### PR DESCRIPTION
### What

Now we don't trim modifiers string, so `<Block modifier=' mod '/>` will have `block block-- block--mod block-- ` class name.

The desired class name would be just `block block--mod`.