### PR TITLE
Get rid of NPE when modifier is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 3.1.1 - 2016-11-29
+### Fix `makeModifiers` plugin
+- Fix a bug related to a null modifier
+
 ## 3.1.0 - 2016-11-29
 ### Fix `makeModifiers` plugin
 - Don't produce empty modifiers in the final class name

--- a/src/plugins/makeModifiers.js
+++ b/src/plugins/makeModifiers.js
@@ -24,7 +24,7 @@
  *
  */
 export const maker = (block, { modifier = '' }, { delimiters }) => {
-  const mod = modifier.trim()
+  const mod = modifier && modifier.trim()
 
   return mod && mod.split(/\s+/).map(item => `${block}${delimiters.modifier}${item}`)
 }

--- a/test/index.js
+++ b/test/index.js
@@ -88,6 +88,13 @@ test('should return `header` block without empty modifier', (t) => {
   )
 })
 
+test('should return `header` block without nullable modifier', (t) => {
+  t.is(
+    justClass({ modifier: null }),
+    'header'
+  )
+})
+
 test('should return `header` block with trimmed modifier', (t) => {
   t.is(
     justClass({ modifier: '  landing ' }),


### PR DESCRIPTION
Apparently, when you define a default value in parameters list, it doesn't affect `null`.

So we will get NPE when calling `null.trim()`.