### PR TITLE
Trim whitespaces from a class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED - XXXX-XX-XX
-### Refactor `makeModifiers` plugin
-- Cleanup the code
+### Remove unnecessary whitespaces from a class name
+- Refactor `makeModifiers` plugin to cleanup the code
 
 ## 3.1.1 - 2016-11-29
 ### Fix `makeModifiers` plugin

--- a/src/filter-object.js
+++ b/src/filter-object.js
@@ -7,7 +7,7 @@
  *
  * @example
  *
- * import filterObject from 'dumb-bem/filter-object'
+ * import filterObject from 'dumb-bem/lib/filter-object'
  *
  * filterObject({ a: 1, b: 2, c: 3}, ['a', 'b'])
  *   // => { c: 3 }

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,10 @@ export default (block, options = {}) => (props) => {
     .filter(a => a)
     .reduce((a, b) => a.concat(b), [])
 
-  const classNames = makers.map(maker => maker(blockName, props, { delimiters }))
+  const classNamesList = makers.map(maker => maker(blockName, props, { delimiters }))
+  const className = cx(classNamesList).trim().replace(/\s\s+/g, ' ')
+
   const knownProps = filterObject(restProps, propsToRemove)
 
-  return { ...knownProps, className: cx(classNames) }
+  return { ...knownProps, className }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import * as pluginModifiers from './plugins/makeModifiers'
 import * as pluginOriginalClass from './plugins/makeOriginalClass'
 
 import filterObject from './filter-object'
+import trimClassName from './trim-class-name'
 
 const basicPlugins = [pluginBlock, pluginModifiers, pluginOriginalClass]
 const defaultDelimiters = {
@@ -26,7 +27,7 @@ export default (block, options = {}) => (props) => {
     .reduce((a, b) => a.concat(b), [])
 
   const classNamesList = makers.map(maker => maker(blockName, props, { delimiters }))
-  const className = cx(classNamesList).trim().replace(/\s\s+/g, ' ')
+  const className = trimClassName(cx(classNamesList))
 
   const knownProps = filterObject(restProps, propsToRemove)
 

--- a/src/plugins/makeBlock.js
+++ b/src/plugins/makeBlock.js
@@ -11,7 +11,7 @@
  *
  * @example
  *
- * import * as pluginBlock from 'dumb-bem/plugins/makeBlock'
+ * import * as pluginBlock from 'dumb-bem/lib/plugins/makeBlock'
  *
  * pluginBlock.maker('block', {})
  *   // => 'block'

--- a/src/plugins/makeModifiers.js
+++ b/src/plugins/makeModifiers.js
@@ -11,7 +11,7 @@
  *
  * @example
  *
- * import * as pluginModifiers from 'dumb-bem/plugins/makeModifiers'
+ * import * as pluginModifiers from 'dumb-bem/lib/plugins/makeModifiers'
  *
  * pluginModifiers.maker('block', { modifier: 'large' }, { delimiters: { modifier: '--' } })
  *   // => 'block--large'

--- a/src/plugins/makeOriginalClass.js
+++ b/src/plugins/makeOriginalClass.js
@@ -12,7 +12,7 @@
  *
  * @example
  *
- * import * as pluginOriginalClass from 'dumb-bem/plugins/makeOriginalClass'
+ * import * as pluginOriginalClass from 'dumb-bem/lib/plugins/makeOriginalClass'
  *
  * pluginOriginalClass.maker('block', { className: 'btn btn-lg btn-success' }, {})
  *   // => 'btn btn-lg btn-success'

--- a/src/plugins/makeStates.js
+++ b/src/plugins/makeStates.js
@@ -15,7 +15,7 @@
  *
  * @example
  *
- * import * as pluginStates from 'dumb-bem/plugins/makeStates'
+ * import * as pluginStates from 'dumb-bem/lib/plugins/makeStates'
  *
  * pluginStates.maker('block', { active: true }, {})
  *   // => 'is-active'

--- a/src/trim-class-name.js
+++ b/src/trim-class-name.js
@@ -7,7 +7,7 @@
  *
  * @example
  *
- * import trimClassName from 'dumb-bem/trim-class-name'
+ * import trimClassName from 'dumb-bem/lib/trim-class-name'
  *
  * trimClassName(' header  header--landing ')
  *   // => 'header header--landing'

--- a/src/trim-class-name.js
+++ b/src/trim-class-name.js
@@ -1,0 +1,16 @@
+/**
+ * @module trimClassName
+ *
+ * @description
+ *
+ * Removes unnecessary whitespaces from a class name string
+ *
+ * @example
+ *
+ * import trimClassName from 'dumb-bem/trim-class-name'
+ *
+ * trimClassName(' header  header--landing ')
+ *   // => 'header header--landing'
+ *
+ */
+export default (className) => className.trim().replace(/\s\s+/g, ' ')

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ import { makeStates } from '../lib/plugins'
 expect.extend(expectJSX)
 
 const dumbHeader = dumbBem('header', { plugins: [makeStates] })
-const justClass = (props) => dumbHeader(props).className.trim()
+const justClass = (props) => dumbHeader(props).className
 
 test('should cleanup unknown properties', (t) => {
   const makeInvisible = {

--- a/test/trim-class-name.js
+++ b/test/trim-class-name.js
@@ -1,0 +1,10 @@
+import test from 'ava'
+
+import trimClassName from '../lib/trim-class-name'
+
+test('should remove all unnecessary whitespaces from a class name string', (t) => {
+  const className = ' header  header--landing   header--meow-meow '
+  const trimmedClassName = trimClassName(className)
+
+  t.is(trimmedClassName, 'header header--landing header--meow-meow')
+})


### PR DESCRIPTION
Some custom makers could add extra whitespace, and in the end the class name looks not that clean as it could.